### PR TITLE
调整默认的目标浏览器

### DIFF
--- a/preset-configs/default.json
+++ b/preset-configs/default.json
@@ -53,7 +53,7 @@
   },
   "envVariables": {},
   "targets": {
-    "browsers": ["> 0.5% and not ie 11 and last 2 versions"]
+    "browsers": ["defaults"]
   },
   "optimization": {
     "addPolyfill": true,

--- a/preset-configs/qiniu/portal.json
+++ b/preset-configs/qiniu/portal.json
@@ -2,11 +2,5 @@
   "extends": "typescript-react",
   "targets": {
     "browsers": ["defaults, not ie 11"]
-  },
-  "transforms": {
-    "svg@js": "raw",
-    "svg@jsx": "raw",
-    "svg@ts": "raw",
-    "svg@tsx": "raw"
   }
 }

--- a/preset-configs/qiniu/portal.json
+++ b/preset-configs/qiniu/portal.json
@@ -1,5 +1,8 @@
 {
   "extends": "typescript-react",
+  "targets": {
+    "browsers": ["defaults, not ie 11"]
+  },
   "transforms": {
     "svg@js": "raw",
     "svg@jsx": "raw",


### PR DESCRIPTION
* 调整 builder 默认 & portal 的目标浏览器

    目前 portal 的访问统计见 https://jira.qiniu.io/browse/RMBWEB-1784

* 调整 portal 的 transforms 配置（跟 typescript-react 一致）

    注：目前 portal-platform、portal-boilerplate 用的还是 `extends: typescript-react`，预期应该调整为 `extends: qiniu/portal` @huangbinjie @lzfee0227 

附，关于 `defaults`

> `defaults`: Browserslist’s default browsers (`> 0.5%, last 2 versions, Firefox ESR, not dead`)

https://github.com/browserslist/browserslist#best-practices

```
➜  npx browserslist "defaults"
and_chr 90
and_ff 87
and_qq 10.4
and_uc 12.12
android 90
baidu 7.12
chrome 90
chrome 89
chrome 88
chrome 87
edge 90
edge 89
edge 88
firefox 87
firefox 86
firefox 78
ie 11
ios_saf 14.0-14.5
ios_saf 13.4-13.7
kaios 2.5
op_mini all
op_mob 62
opera 75
opera 74
safari 14
safari 13.1
samsung 13.0
samsung 12.0
```
